### PR TITLE
build: add bin alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
-        "patternfly-mcp": "dist/index.js"
+        "patternfly-mcp": "dist/index.js",
+        "pf-mcp": "dist/index.js",
+        "pfmcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "patternfly-mcp": "dist/index.js"
+    "patternfly-mcp": "dist/index.js",
+    "pf-mcp": "dist/index.js",
+    "pfmcp": "dist/index.js"
   },
   "files": [
     "dist/**/*",


### PR DESCRIPTION
## What is it?
- build: add bin alias

## Notes
- just adds additional shortcuts/aliases for the bin/cli ref
   - `pf-mcp`
   - `pfmcp`